### PR TITLE
Refactor to PHP 8.4 property hooks and asymmetric visibility

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use RectorLaravel\Set\LaravelLevelSetList;
 
 return RectorConfig::configure()
@@ -21,5 +22,10 @@ return RectorConfig::configure()
     )
     ->withSets([
         LaravelLevelSetList::UP_TO_LARAVEL_120,
+    ])
+    ->withSkip([
+        // Rector incorrectly infers Pest\Mixins\Expectation instead of Pest\Expectation
+        AddArrowFunctionReturnTypeRector::class => [
+            __DIR__.'/tests',
+        ],
     ]);
-// ->withPhpSets(php84: true)

--- a/src/Platform.php
+++ b/src/Platform.php
@@ -50,5 +50,4 @@ class Platform
     {
         return new AnalyticsRequest($this);
     }
-
 }

--- a/src/Platform.php
+++ b/src/Platform.php
@@ -12,7 +12,7 @@ use Cjmellor\FalAi\Support\UsageRequest;
 
 class Platform
 {
-    protected PlatformConnector $connector;
+    public protected(set) PlatformConnector $connector;
 
     public function __construct()
     {
@@ -51,11 +51,4 @@ class Platform
         return new AnalyticsRequest($this);
     }
 
-    /**
-     * Get the platform connector instance
-     */
-    public function getConnector(): PlatformConnector
-    {
-        return $this->connector;
-    }
 }

--- a/src/Support/AnalyticsRequest.php
+++ b/src/Support/AnalyticsRequest.php
@@ -14,19 +14,30 @@ class AnalyticsRequest
 {
     use Conditionable;
 
-    /** @var array<string> */
-    private array $endpointIds = [];
+    /**
+     * Get the current endpoint IDs
+     *
+     * @var array<string>
+     */
+    public private(set) array $endpointIds = [];
 
-    /** @var array<string> */
-    private array $expand = ['time_series', 'request_count'];
+    /**
+     * Get the current expand options
+     *
+     * @var array<string>
+     */
+    public private(set) array $expand = ['time_series', 'request_count'];
+
+    /**
+     * Get the current timeframe
+     */
+    public private(set) ?string $timeframe = null;
 
     private ?string $start = null;
 
     private ?string $end = null;
 
     private ?string $timezone = null;
-
-    private ?string $timeframe = null;
 
     private ?bool $boundToTimeframe = null;
 
@@ -344,36 +355,8 @@ class AnalyticsRequest
             cursor: $this->cursor,
         );
 
-        $response = $this->platform->getConnector()->send($request);
+        $response = $this->platform->connector->send($request);
 
         return new AnalyticsResponse($response, $response->json());
-    }
-
-    /**
-     * Get the current endpoint IDs
-     *
-     * @return array<string>
-     */
-    public function getEndpointIds(): array
-    {
-        return $this->endpointIds;
-    }
-
-    /**
-     * Get the current expand options
-     *
-     * @return array<string>
-     */
-    public function getExpand(): array
-    {
-        return $this->expand;
-    }
-
-    /**
-     * Get the current timeframe
-     */
-    public function getTimeframe(): ?string
-    {
-        return $this->timeframe;
     }
 }

--- a/src/Support/FluentRequest.php
+++ b/src/Support/FluentRequest.php
@@ -17,15 +17,24 @@ class FluentRequest implements FluentRequestInterface
 {
     use Conditionable;
 
-    private array $data = [];
+    /**
+     * Get the current data array
+     */
+    public private(set) array $data = [];
+
+    /**
+     * Get the current base URL override
+     */
+    public private(set) ?string $baseUrlOverride = null;
+
+    /**
+     * Get the current webhook URL
+     */
+    public private(set) ?string $webhookUrl = null;
 
     private ?string $modelId;
 
     private FalAi $falAi;
-
-    private ?string $baseUrlOverride = null;
-
-    private ?string $webhookUrl = null;
 
     public function __construct(FalAi $falAi, ?string $modelId)
     {
@@ -143,14 +152,6 @@ class FluentRequest implements FluentRequestInterface
     }
 
     /**
-     * Get the current data array
-     */
-    public function getData(): array
-    {
-        return $this->data;
-    }
-
-    /**
      * Get all data as an array
      */
     public function toArray(): array
@@ -185,21 +186,5 @@ class FluentRequest implements FluentRequestInterface
         $clone->data = array_merge($this->data, $data);
 
         return $clone;
-    }
-
-    /**
-     * Get the current base URL override
-     */
-    public function getBaseUrlOverride(): ?string
-    {
-        return $this->baseUrlOverride;
-    }
-
-    /**
-     * Get the current webhook URL
-     */
-    public function getWebhookUrl(): ?string
-    {
-        return $this->webhookUrl;
     }
 }

--- a/src/Support/PricingRequest.php
+++ b/src/Support/PricingRequest.php
@@ -14,8 +14,12 @@ class PricingRequest
 {
     use Conditionable;
 
-    /** @var array<string> */
-    private array $endpointIds = [];
+    /**
+     * Get the current endpoint IDs
+     *
+     * @var array<string>
+     */
+    public private(set) array $endpointIds = [];
 
     private Platform $platform;
 
@@ -60,18 +64,8 @@ class PricingRequest
     public function get(): PricingResponse
     {
         $request = new GetPricingRequest($this->endpointIds);
-        $response = $this->platform->getConnector()->send($request);
+        $response = $this->platform->connector->send($request);
 
         return new PricingResponse($response, $response->json());
-    }
-
-    /**
-     * Get the current endpoint IDs
-     *
-     * @return array<string>
-     */
-    public function getEndpointIds(): array
-    {
-        return $this->endpointIds;
     }
 }

--- a/src/Support/UsageRequest.php
+++ b/src/Support/UsageRequest.php
@@ -14,19 +14,30 @@ class UsageRequest
 {
     use Conditionable;
 
-    /** @var array<string> */
-    private array $endpointIds = [];
+    /**
+     * Get the current endpoint IDs
+     *
+     * @var array<string>
+     */
+    public private(set) array $endpointIds = [];
 
-    /** @var array<string> */
-    private array $expand = ['time_series'];
+    /**
+     * Get the current expand options
+     *
+     * @var array<string>
+     */
+    public private(set) array $expand = ['time_series'];
+
+    /**
+     * Get the current timeframe
+     */
+    public private(set) ?string $timeframe = null;
 
     private ?string $start = null;
 
     private ?string $end = null;
 
     private ?string $timezone = null;
-
-    private ?string $timeframe = null;
 
     private ?bool $boundToTimeframe = null;
 
@@ -238,36 +249,8 @@ class UsageRequest
             cursor: $this->cursor,
         );
 
-        $response = $this->platform->getConnector()->send($request);
+        $response = $this->platform->connector->send($request);
 
         return new UsageResponse($response, $response->json());
-    }
-
-    /**
-     * Get the current endpoint IDs
-     *
-     * @return array<string>
-     */
-    public function getEndpointIds(): array
-    {
-        return $this->endpointIds;
-    }
-
-    /**
-     * Get the current expand options
-     *
-     * @return array<string>
-     */
-    public function getExpand(): array
-    {
-        return $this->expand;
-    }
-
-    /**
-     * Get the current timeframe
-     */
-    public function getTimeframe(): ?string
-    {
-        return $this->timeframe;
     }
 }

--- a/tests/Feature/PlatformApiTest.php
+++ b/tests/Feature/PlatformApiTest.php
@@ -169,7 +169,7 @@ describe('Platform Estimate Cost API', function (): void {
 
         $builder = $falAi->platform()->estimateCost();
 
-        expect($builder->getEstimateType())->toBe('historical_api_price');
+        expect($builder->estimateType)->toBe('historical_api_price');
     });
 
 });
@@ -208,7 +208,7 @@ describe('Platform Pricing Request Builder', function (): void {
             ->forEndpoint('fal-ai/flux/dev')
             ->forEndpoint('fal-ai/flux/schnell');
 
-        expect($builder->getEndpointIds())->toBe([
+        expect($builder->endpointIds)->toBe([
             'fal-ai/flux/dev',
             'fal-ai/flux/schnell',
         ]);
@@ -225,7 +225,7 @@ describe('Platform Estimate Cost Request Builder', function (): void {
             ->endpoint('fal-ai/flux/dev', callQuantity: 100)
             ->endpoint('fal-ai/flux/schnell', unitQuantity: 50);
 
-        expect($builder->getEndpoints())->toBe([
+        expect($builder->configuredEndpoints)->toBe([
             'fal-ai/flux/dev' => ['call_quantity' => 100],
             'fal-ai/flux/schnell' => ['unit_quantity' => 50],
         ]);
@@ -236,13 +236,13 @@ describe('Platform Estimate Cost Request Builder', function (): void {
 
         $builder = $falAi->platform()->estimateCost()
             ->historicalApiPrice();
-        expect($builder->getEstimateType())->toBe('historical_api_price');
+        expect($builder->estimateType)->toBe('historical_api_price');
 
         $builder->unitPrice();
-        expect($builder->getEstimateType())->toBe('unit_price');
+        expect($builder->estimateType)->toBe('unit_price');
 
         $builder->historicalApiPrice();
-        expect($builder->getEstimateType())->toBe('historical_api_price');
+        expect($builder->estimateType)->toBe('historical_api_price');
     });
 
 });
@@ -376,9 +376,9 @@ describe('Platform Usage Request Builder', function (): void {
             ->withSummary()
             ->withAuthMethod();
 
-        expect($builder->getExpand())->toContain('time_series')
-            ->and($builder->getExpand())->toContain('summary')
-            ->and($builder->getExpand())->toContain('auth_method');
+        expect($builder->expand)->toContain('time_series')
+            ->and($builder->expand)->toContain('summary')
+            ->and($builder->expand)->toContain('auth_method');
     });
 
     it('can set date range with from and to', function (): void {
@@ -541,7 +541,7 @@ describe('Platform Analytics Request Builder', function (): void {
             ->withAllErrors()
             ->withP90Duration();
 
-        $expand = $builder->getExpand();
+        $expand = $builder->expand;
 
         expect($expand)->toContain('request_count')
             ->and($expand)->toContain('success_count')
@@ -557,7 +557,7 @@ describe('Platform Analytics Request Builder', function (): void {
             ->forEndpoint('fal-ai/flux/dev')
             ->withAllMetrics();
 
-        $expand = $builder->getExpand();
+        $expand = $builder->expand;
 
         expect($expand)->toContain('time_series')
             ->and($expand)->toContain('request_count')

--- a/tests/Integration/WebhookIntegrationTest.php
+++ b/tests/Integration/WebhookIntegrationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Cjmellor\FalAi\FalAi;
 use Cjmellor\FalAi\Requests\SubmitRequest;
-use InvalidArgumentException;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
@@ -33,7 +32,7 @@ it('completes webhook flow', function (): void {
         ->numImages(1);
 
     // Verify webhook URL is set
-    expect($request->getWebhookUrl())->toBe($webhookUrl);
+    expect($request->webhookUrl)->toBe($webhookUrl);
 
     // Execute the request
     $response = $request->run();
@@ -87,15 +86,15 @@ it('allows webhook url to be changed', function (): void {
         ->prompt('Test prompt');
 
     // Initially no webhook
-    expect($request->getWebhookUrl())->toBeNull();
+    expect($request->webhookUrl)->toBeNull();
 
     // Set first webhook
     $request->withWebhook('https://app1.com/webhook');
-    expect($request->getWebhookUrl())->toBe('https://app1.com/webhook');
+    expect($request->webhookUrl)->toBe('https://app1.com/webhook');
 
     // Change to second webhook
     $request->withWebhook('https://app2.com/webhook');
-    expect($request->getWebhookUrl())->toBe('https://app2.com/webhook');
+    expect($request->webhookUrl)->toBe('https://app2.com/webhook');
 });
 
 it('works with other fluent methods', function (): void {

--- a/tests/Unit/FluentRequestTest.php
+++ b/tests/Unit/FluentRequestTest.php
@@ -82,7 +82,7 @@ describe('FluentRequest Dynamic Methods', function (): void {
 
         expect($request)
             ->toBeInstanceOf(FluentRequest::class)
-            ->getBaseUrlOverride()->toBe($expectedUrl)
+            ->baseUrlOverride->toBe($expectedUrl)
             ->and($request->toArray())->toBeArray();
     })->with([
         'queue method' => ['queue', 'https://queue.fal.run'],

--- a/tests/Unit/WebhookFluentRequestTest.php
+++ b/tests/Unit/WebhookFluentRequestTest.php
@@ -13,7 +13,7 @@ it('sets webhook url with withWebhook', function (): void {
 
     expect($result)
         ->toBeInstanceOf(FluentRequest::class)
-        ->and($result->getWebhookUrl())->toBe($webhookUrl);
+        ->and($result->webhookUrl)->toBe($webhookUrl);
 });
 
 it('validates webhook url', function (): void {
@@ -34,28 +34,28 @@ it('automatically uses queue when webhook is set', function (): void {
     $request = new FluentRequest(new FalAi('test-key'), 'test-model');
     $webhookUrl = 'https://example.com/webhook';
 
-    expect($request->getBaseUrlOverride())->toBeNull();
+    expect($request->baseUrlOverride)->toBeNull();
 
     $request->withWebhook($webhookUrl);
 
-    expect($request->getBaseUrlOverride())->toBe('https://queue.fal.run');
+    expect($request->baseUrlOverride)->toBe('https://queue.fal.run');
 });
 
 it('returns null when webhook url is not set', function (): void {
     $request = new FluentRequest(new FalAi('test-key'), 'test-model');
 
-    expect($request->getWebhookUrl())->toBeNull();
+    expect($request->webhookUrl)->toBeNull();
 });
 
 it('sets webhook url correctly', function (): void {
     $request = new FluentRequest(new FalAi('test-key'), 'test-model');
     $webhookUrl = 'https://example.com/webhook';
 
-    expect($request->getWebhookUrl())->toBeNull();
+    expect($request->webhookUrl)->toBeNull();
 
     $request->withWebhook($webhookUrl);
 
-    expect($request->getWebhookUrl())->toBe($webhookUrl);
+    expect($request->webhookUrl)->toBe($webhookUrl);
 });
 
 covers(FluentRequest::class);


### PR DESCRIPTION
## Summary

- Converts getter methods to PHP 8.4 asymmetric visibility (`public private(set)`) for cleaner property access
- Properties are now publicly readable but only internally mutable
- Removes boilerplate getter methods while maintaining encapsulation

## Changes

**Support Classes:**
- `FluentRequest`: `$data`, `$baseUrlOverride`, `$webhookUrl`
- `PricingRequest`: `$endpointIds`
- `EstimateCostRequest`: `$estimateType`, `$configuredEndpoints`
- `UsageRequest`: `$endpointIds`, `$expand`, `$timeframe`
- `AnalyticsRequest`: `$endpointIds`, `$expand`, `$timeframe`

**Platform Class:**
- `$connector` with `protected(set)`, removed `getConnector()` method

**Other:**
- Updated all tests to use property access instead of getter methods
- Added Rector skip rule for test directory type inference issue
- Simplified CLAUDE.md documentation

## Test plan

- [x] All 275 tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)