### PR TITLE
Add preventStrayRequests() to prevent real API calls in tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,17 @@ namespace Cjmellor\FalAi\Tests;
 use Cjmellor\FalAi\FalAiServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Saloon\Config;
 
 class TestCase extends Orchestra
 {
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Prevent any unmocked HTTP requests from going through to real APIs
+        // This will throw an exception if any test tries to make a real API call
+        Config::preventStrayRequests();
 
         Factory::guessFactoryNamesUsing(
             fn (string $modelName): string => 'Cjmellor\\FalAi\\Database\\Factories\\'.class_basename($modelName).'Factory'


### PR DESCRIPTION
## Summary
- Adds Saloon's `Config::preventStrayRequests()` to the TestCase setUp method
- Ensures any test that attempts to make an unmocked HTTP request will fail immediately with a clear error
- Prevents accidental real API calls that could incur costs

## Test plan
- [x] All 567 tests pass
- [x] Verified the safety net works by confirming existing mocks are properly set up