### PR TITLE
Add Replicate Deployments API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.docs
 vendor
 /workbench/*
 !/workbench/routes

--- a/src/Drivers/Replicate/Enums/Hardware.php
+++ b/src/Drivers/Replicate/Enums/Hardware.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Enums;
+
+/**
+ * Available hardware SKUs for Replicate deployments and model runs.
+ */
+enum Hardware: string
+{
+    case Cpu = 'cpu';
+    case GpuA100Large = 'gpu-a100-large';
+    case GpuA100Large2x = 'gpu-a100-large-2x';
+    case GpuH100 = 'gpu-h100';
+    case GpuL40s = 'gpu-l40s';
+    case GpuL40s2x = 'gpu-l40s-2x';
+    case GpuT4 = 'gpu-t4';
+}

--- a/src/Drivers/Replicate/Requests/Deployments/CreateDeploymentPredictionRequest.php
+++ b/src/Drivers/Replicate/Requests/Deployments/CreateDeploymentPredictionRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Create a prediction using a specific deployment.
+ *
+ * @see https://replicate.com/docs/reference/http#create-a-prediction-using-a-deployment
+ */
+class CreateDeploymentPredictionRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param  string  $owner  The owner of the deployment
+     * @param  string  $name  The name of the deployment
+     * @param  array<string, mixed>  $input  The model input parameters
+     * @param  string|null  $webhookUrl  Optional webhook URL for async notifications
+     * @param  array<int, string>  $webhookEventsFilter  Events to filter for webhook
+     */
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $name,
+        protected readonly array $input = [],
+        protected readonly ?string $webhookUrl = null,
+        protected readonly array $webhookEventsFilter = [],
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/v1/deployments/{$this->owner}/{$this->name}/predictions";
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function defaultBody(): array
+    {
+        $body = [
+            'input' => $this->input,
+        ];
+
+        if (filled($this->webhookUrl)) {
+            $body['webhook'] = $this->webhookUrl;
+        }
+
+        if (filled($this->webhookEventsFilter)) {
+            $body['webhook_events_filter'] = $this->webhookEventsFilter;
+        }
+
+        return $body;
+    }
+}

--- a/src/Drivers/Replicate/Requests/Deployments/CreateDeploymentRequest.php
+++ b/src/Drivers/Replicate/Requests/Deployments/CreateDeploymentRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Create a new deployment.
+ *
+ * @see https://replicate.com/docs/reference/http#create-a-deployment
+ */
+class CreateDeploymentRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param  string  $name  The name of the deployment
+     * @param  string  $model  The model identifier in "owner/name" format
+     * @param  string  $version  The model version ID (64 char hex)
+     * @param  string  $hardware  The hardware SKU (e.g., "gpu-t4", "gpu-a40-small")
+     * @param  int  $minInstances  Minimum number of instances
+     * @param  int  $maxInstances  Maximum number of instances
+     */
+    public function __construct(
+        protected readonly string $name,
+        protected readonly string $model,
+        protected readonly string $version,
+        protected readonly string $hardware,
+        protected readonly int $minInstances,
+        protected readonly int $maxInstances,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/v1/deployments';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function defaultBody(): array
+    {
+        return [
+            'name' => $this->name,
+            'model' => $this->model,
+            'version' => $this->version,
+            'hardware' => $this->hardware,
+            'min_instances' => $this->minInstances,
+            'max_instances' => $this->maxInstances,
+        ];
+    }
+}

--- a/src/Drivers/Replicate/Requests/Deployments/DeleteDeploymentRequest.php
+++ b/src/Drivers/Replicate/Requests/Deployments/DeleteDeploymentRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * Delete a deployment.
+ *
+ * @see https://replicate.com/docs/reference/http#delete-a-deployment
+ */
+class DeleteDeploymentRequest extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $name,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/v1/deployments/{$this->owner}/{$this->name}";
+    }
+}

--- a/src/Drivers/Replicate/Requests/Deployments/GetDeploymentRequest.php
+++ b/src/Drivers/Replicate/Requests/Deployments/GetDeploymentRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * Get a specific deployment by owner and name.
+ *
+ * @see https://replicate.com/docs/reference/http#get-a-deployment
+ */
+class GetDeploymentRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $name,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/v1/deployments/{$this->owner}/{$this->name}";
+    }
+}

--- a/src/Drivers/Replicate/Requests/Deployments/ListDeploymentsRequest.php
+++ b/src/Drivers/Replicate/Requests/Deployments/ListDeploymentsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * List all deployments for the authenticated user.
+ *
+ * @see https://replicate.com/docs/reference/http#list-deployments
+ */
+class ListDeploymentsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function resolveEndpoint(): string
+    {
+        return '/v1/deployments';
+    }
+}

--- a/src/Drivers/Replicate/Requests/Deployments/UpdateDeploymentRequest.php
+++ b/src/Drivers/Replicate/Requests/Deployments/UpdateDeploymentRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Update an existing deployment.
+ *
+ * @see https://replicate.com/docs/reference/http#update-a-deployment
+ */
+class UpdateDeploymentRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::PATCH;
+
+    /**
+     * @param  string  $owner  The owner of the deployment
+     * @param  string  $name  The name of the deployment
+     * @param  array<string, mixed>  $updates  The fields to update
+     */
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $name,
+        protected readonly array $updates,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/v1/deployments/{$this->owner}/{$this->name}";
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function defaultBody(): array
+    {
+        return $this->updates;
+    }
+}

--- a/src/Drivers/Replicate/Responses/DeploymentResponse.php
+++ b/src/Drivers/Replicate/Responses/DeploymentResponse.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Responses;
+
+use Cjmellor\FalAi\Responses\AbstractResponse;
+
+/**
+ * Response wrapper for Replicate deployment operations.
+ *
+ * Wraps the raw Saloon response with typed accessors for deployment data.
+ */
+class DeploymentResponse extends AbstractResponse
+{
+    /**
+     * Get the deployment owner
+     */
+    public ?string $owner {
+        get => $this->data['owner'] ?? null;
+    }
+
+    /**
+     * Get the deployment name
+     */
+    public ?string $name {
+        get => $this->data['name'] ?? null;
+    }
+
+    /**
+     * Get the current release information
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $currentRelease {
+        get => $this->data['current_release'] ?? null;
+    }
+
+    /**
+     * Get the hardware SKU from current release
+     */
+    public function hardware(): ?string
+    {
+        return $this->currentRelease['hardware'] ?? null;
+    }
+
+    /**
+     * Get the model identifier from current release
+     */
+    public function model(): ?string
+    {
+        return $this->currentRelease['model'] ?? null;
+    }
+
+    /**
+     * Get the model version from current release
+     */
+    public function version(): ?string
+    {
+        return $this->currentRelease['version'] ?? null;
+    }
+
+    /**
+     * Get the minimum instances from current release
+     */
+    public function minInstances(): ?int
+    {
+        $value = $this->currentRelease['min_instances'] ?? null;
+
+        return $value !== null ? (int) $value : null;
+    }
+
+    /**
+     * Get the maximum instances from current release
+     */
+    public function maxInstances(): ?int
+    {
+        $value = $this->currentRelease['max_instances'] ?? null;
+
+        return $value !== null ? (int) $value : null;
+    }
+
+    /**
+     * Get the release number from current release
+     */
+    public function releaseNumber(): ?int
+    {
+        $value = $this->currentRelease['number'] ?? null;
+
+        return $value !== null ? (int) $value : null;
+    }
+
+    /**
+     * Get the created_at timestamp from current release
+     */
+    public function createdAt(): ?string
+    {
+        return $this->currentRelease['created_at'] ?? null;
+    }
+
+    /**
+     * Get the created_by information from current release
+     *
+     * @return array<string, mixed>|null
+     */
+    public function createdBy(): ?array
+    {
+        return $this->currentRelease['created_by'] ?? null;
+    }
+}

--- a/src/Drivers/Replicate/Responses/DeploymentsCollection.php
+++ b/src/Drivers/Replicate/Responses/DeploymentsCollection.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Responses;
+
+use Saloon\Http\Response;
+
+/**
+ * Collection wrapper for paginated deployment list responses.
+ *
+ * Provides iteration and pagination helpers for deployment listings.
+ */
+class DeploymentsCollection
+{
+    /** @var array<int, DeploymentResponse> */
+    protected array $deployments = [];
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __construct(
+        protected Response $response,
+        protected array $data,
+    ) {
+        $this->hydrate();
+    }
+
+    /**
+     * Get all deployments in this page.
+     *
+     * @return array<int, DeploymentResponse>
+     */
+    public function results(): array
+    {
+        return $this->deployments;
+    }
+
+    /**
+     * Get the URL for the next page of results.
+     */
+    public function next(): ?string
+    {
+        return $this->data['next'] ?? null;
+    }
+
+    /**
+     * Get the URL for the previous page of results.
+     */
+    public function previous(): ?string
+    {
+        return $this->data['previous'] ?? null;
+    }
+
+    /**
+     * Check if there are more results available.
+     */
+    public function hasMore(): bool
+    {
+        return $this->next() !== null;
+    }
+
+    /**
+     * Get the count of deployments in this page.
+     */
+    public function count(): int
+    {
+        return count($this->deployments);
+    }
+
+    /**
+     * Get the raw response data.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * Get the underlying Saloon response.
+     */
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    /**
+     * Hydrate the collection with deployment responses.
+     */
+    protected function hydrate(): void
+    {
+        $results = $this->data['results'] ?? [];
+
+        foreach ($results as $deploymentData) {
+            $this->deployments[] = new DeploymentResponse($this->response, $deploymentData);
+        }
+    }
+}

--- a/src/Drivers/Replicate/Support/DeploymentBuilder.php
+++ b/src/Drivers/Replicate/Support/DeploymentBuilder.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Support;
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateConnector;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\UpdateDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Cjmellor\FalAi\Exceptions\InvalidConfigurationException;
+
+/**
+ * Fluent builder for creating and updating Replicate deployments.
+ *
+ * For create: FalAi::driver('replicate')->deployments()->create('name')
+ *     ->model('owner/model')->version('abc...')->hardware('gpu-t4')->instances(1, 5)->save()
+ *
+ * For update: FalAi::driver('replicate')->deployments()->update('owner', 'name')
+ *     ->hardware('gpu-a40-small')->instances(2, 10)->save()
+ */
+final class DeploymentBuilder
+{
+    private ?string $model = null;
+
+    private ?string $version = null;
+
+    private ?string $hardware = null;
+
+    private ?int $minInstances = null;
+
+    private ?int $maxInstances = null;
+
+    public function __construct(
+        private ReplicateConnector $connector,
+        private string $name,
+        private bool $isUpdate = false,
+        private ?string $owner = null,
+    ) {}
+
+    /**
+     * Set the model for the deployment (owner/name format).
+     */
+    public function model(string $model): self
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * Set the model version for the deployment (64 char hex).
+     */
+    public function version(string $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    /**
+     * Set the hardware SKU for the deployment.
+     */
+    public function hardware(string $hardware): self
+    {
+        $this->hardware = $hardware;
+
+        return $this;
+    }
+
+    /**
+     * Set the instance scaling limits.
+     */
+    public function instances(int $min, int $max): self
+    {
+        $this->minInstances = $min;
+        $this->maxInstances = $max;
+
+        return $this;
+    }
+
+    /**
+     * Save the deployment (create or update).
+     *
+     * @throws InvalidConfigurationException When required fields are missing
+     */
+    public function save(): DeploymentResponse
+    {
+        if ($this->isUpdate) {
+            return $this->performUpdate();
+        }
+
+        return $this->performCreate();
+    }
+
+    /**
+     * Perform a create operation.
+     *
+     * @throws InvalidConfigurationException When required fields are missing
+     */
+    private function performCreate(): DeploymentResponse
+    {
+        $this->validateCreateFields();
+
+        $request = new CreateDeploymentRequest(
+            name: $this->name,
+            model: $this->model,
+            version: $this->version,
+            hardware: $this->hardware,
+            minInstances: $this->minInstances,
+            maxInstances: $this->maxInstances,
+        );
+
+        $response = $this->connector->send($request);
+
+        return new DeploymentResponse($response, $response->json());
+    }
+
+    /**
+     * Perform an update operation.
+     */
+    private function performUpdate(): DeploymentResponse
+    {
+        $updates = $this->buildUpdatePayload();
+
+        $request = new UpdateDeploymentRequest(
+            owner: $this->owner,
+            name: $this->name,
+            updates: $updates,
+        );
+
+        $response = $this->connector->send($request);
+
+        return new DeploymentResponse($response, $response->json());
+    }
+
+    /**
+     * Validate that all required fields are set for create.
+     *
+     * @throws InvalidConfigurationException When required fields are missing
+     */
+    private function validateCreateFields(): void
+    {
+        $missing = [];
+
+        if ($this->model === null) {
+            $missing[] = 'model';
+        }
+
+        if ($this->version === null) {
+            $missing[] = 'version';
+        }
+
+        if ($this->hardware === null) {
+            $missing[] = 'hardware';
+        }
+
+        if ($this->minInstances === null || $this->maxInstances === null) {
+            $missing[] = 'instances (min and max)';
+        }
+
+        throw_if(
+            count($missing) > 0,
+            new InvalidConfigurationException('Missing required deployment fields: '.implode(', ', $missing))
+        );
+    }
+
+    /**
+     * Build the update payload with only set fields.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildUpdatePayload(): array
+    {
+        $updates = [];
+
+        if ($this->model !== null) {
+            $updates['model'] = $this->model;
+        }
+
+        if ($this->version !== null) {
+            $updates['version'] = $this->version;
+        }
+
+        if ($this->hardware !== null) {
+            $updates['hardware'] = $this->hardware;
+        }
+
+        if ($this->minInstances !== null) {
+            $updates['min_instances'] = $this->minInstances;
+        }
+
+        if ($this->maxInstances !== null) {
+            $updates['max_instances'] = $this->maxInstances;
+        }
+
+        return $updates;
+    }
+}

--- a/src/Drivers/Replicate/Support/DeploymentPredictionRequest.php
+++ b/src/Drivers/Replicate/Support/DeploymentPredictionRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Support;
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateConnector;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentPredictionRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\PredictionResponse;
+
+/**
+ * Fluent builder for creating predictions via a deployment.
+ *
+ * Usage: FalAi::driver('replicate')->deployment('owner/name')
+ *     ->with(['prompt' => 'A sunset'])->webhook('https://...')->run()
+ */
+final class DeploymentPredictionRequest
+{
+    /** @var array<string, mixed> */
+    private array $input = [];
+
+    private ?string $webhookUrl = null;
+
+    /** @var array<int, string> */
+    private array $webhookEvents = ['completed'];
+
+    public function __construct(
+        private ReplicateConnector $connector,
+        private string $owner,
+        private string $name,
+    ) {}
+
+    /**
+     * Set the input parameters for the prediction.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function with(array $input): self
+    {
+        $this->input = $input;
+
+        return $this;
+    }
+
+    /**
+     * Set a webhook URL for async notifications.
+     *
+     * @param  array<int, string>  $events  Events to subscribe to (start, output, logs, completed)
+     */
+    public function webhook(string $url, array $events = ['completed']): self
+    {
+        $this->webhookUrl = $url;
+        $this->webhookEvents = $events;
+
+        return $this;
+    }
+
+    /**
+     * Execute the prediction.
+     */
+    public function run(): PredictionResponse
+    {
+        $request = new CreateDeploymentPredictionRequest(
+            owner: $this->owner,
+            name: $this->name,
+            input: $this->input,
+            webhookUrl: $this->webhookUrl,
+            webhookEventsFilter: $this->webhookUrl ? $this->webhookEvents : [],
+        );
+
+        $response = $this->connector->send($request);
+
+        return new PredictionResponse($response, $response->json());
+    }
+}

--- a/src/Drivers/Replicate/Support/DeploymentsManager.php
+++ b/src/Drivers/Replicate/Support/DeploymentsManager.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Drivers\Replicate\Support;
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateConnector;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\DeleteDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\GetDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\ListDeploymentsRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentsCollection;
+
+/**
+ * Manager class for Replicate deployments CRUD operations.
+ *
+ * Provides fluent access to deployment listing, retrieval, creation, update, and deletion.
+ */
+final class DeploymentsManager
+{
+    public function __construct(
+        private ReplicateConnector $connector,
+    ) {}
+
+    /**
+     * List all deployments for the authenticated user.
+     */
+    public function list(): DeploymentsCollection
+    {
+        $response = $this->connector->send(new ListDeploymentsRequest);
+
+        return new DeploymentsCollection($response, $response->json());
+    }
+
+    /**
+     * Get a specific deployment by owner and name.
+     */
+    public function get(string $owner, string $name): DeploymentResponse
+    {
+        $response = $this->connector->send(new GetDeploymentRequest($owner, $name));
+
+        return new DeploymentResponse($response, $response->json());
+    }
+
+    /**
+     * Create a new deployment builder.
+     */
+    public function create(string $name): DeploymentBuilder
+    {
+        return new DeploymentBuilder($this->connector, $name, isUpdate: false);
+    }
+
+    /**
+     * Update an existing deployment.
+     */
+    public function update(string $owner, string $name): DeploymentBuilder
+    {
+        return new DeploymentBuilder($this->connector, $name, isUpdate: true, owner: $owner);
+    }
+
+    /**
+     * Delete a deployment.
+     *
+     * @return bool True if deletion was successful
+     */
+    public function delete(string $owner, string $name): bool
+    {
+        $response = $this->connector->send(new DeleteDeploymentRequest($owner, $name));
+
+        return $response->successful();
+    }
+}

--- a/src/Exceptions/InvalidConfigurationException.php
+++ b/src/Exceptions/InvalidConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\FalAi\Exceptions;
+
+class InvalidConfigurationException extends FalAiException
+{
+    //
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -76,3 +76,18 @@ arch('Replicate driver does not depend on Fal driver')
 arch('Fal driver does not depend on Replicate driver')
     ->expect('Cjmellor\FalAi\Drivers\Fal')
     ->not->toUse('Cjmellor\FalAi\Drivers\Replicate');
+
+// Ensure Replicate deployment requests extend Saloon Request
+arch('Replicate deployment requests extend Saloon Request')
+    ->expect('Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments')
+    ->toExtend(Request::class);
+
+// Ensure Replicate deployment responses extend AbstractResponse
+arch('Replicate DeploymentResponse extends AbstractResponse')
+    ->expect('Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse')
+    ->toExtend(Cjmellor\FalAi\Responses\AbstractResponse::class);
+
+// Ensure support classes are final
+arch('Replicate support classes are final')
+    ->expect('Cjmellor\FalAi\Drivers\Replicate\Support')
+    ->toBeFinal();

--- a/tests/Feature/ReplicateDeploymentsTest.php
+++ b/tests/Feature/ReplicateDeploymentsTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateDriver;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentPredictionRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\DeleteDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\GetDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\ListDeploymentsRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\UpdateDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentsCollection;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\PredictionResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Support\DeploymentsManager;
+use Cjmellor\FalAi\Facades\FalAi;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+
+beforeEach(function (): void {
+    config([
+        'fal-ai.default' => 'replicate',
+        'fal-ai.drivers.replicate.api_key' => 'test-replicate-key',
+        'fal-ai.drivers.replicate.base_url' => 'https://api.replicate.com',
+    ]);
+
+    app()->forgetInstance('fal-ai');
+});
+
+function replicateDriver(): ReplicateDriver
+{
+    $driver = FalAi::driver('replicate');
+    assert($driver instanceof ReplicateDriver);
+
+    return $driver;
+}
+
+describe('Replicate Deployments API via Facade', function (): void {
+
+    it('accesses deployments manager via facade', function (): void {
+        $manager = replicateDriver()->deployments();
+
+        expect($manager)->toBeInstanceOf(DeploymentsManager::class);
+    });
+
+    it('lists deployments via facade', function (): void {
+        Saloon::fake([
+            ListDeploymentsRequest::class => MockResponse::fixture('Replicate/Deployments/list-deployments-success'),
+        ]);
+
+        $collection = replicateDriver()->deployments()->list();
+
+        expect($collection)
+            ->toBeInstanceOf(DeploymentsCollection::class)
+            ->and($collection)->count()->toBe(2)
+            ->and($collection->results())->sequence(
+                fn ($item) => $item->name->toBe('deployment-one'),
+                fn ($item) => $item->name->toBe('deployment-two'),
+            );
+    });
+
+    it('gets a deployment via facade', function (): void {
+        Saloon::fake([
+            GetDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/get-deployment-success'),
+        ]);
+
+        $response = replicateDriver()->deployments()->get('acme', 'my-deployment');
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class)
+            ->and($response)->owner->toBe('acme')
+            ->and($response)->name->toBe('my-deployment')
+            ->and($response)->hardware()->toBe('gpu-t4')
+            ->and($response)->minInstances()->toBe(1)
+            ->and($response)->maxInstances()->toBe(5);
+    });
+
+    it('creates a deployment via facade', function (): void {
+        Saloon::fake([
+            CreateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-success'),
+        ]);
+
+        $response = replicateDriver()
+            ->deployments()
+            ->create('my-deployment')
+            ->model('stability-ai/sdxl')
+            ->version('da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf')
+            ->hardware('gpu-t4')
+            ->instances(1, 5)
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class)
+            ->and($response)->name->toBe('my-deployment');
+    });
+
+    it('updates a deployment via facade', function (): void {
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $response = replicateDriver()
+            ->deployments()
+            ->update('acme', 'my-deployment')
+            ->hardware('gpu-a40-small')
+            ->instances(2, 10)
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class)
+            ->and($response)->hardware()->toBe('gpu-a40-small')
+            ->and($response)->minInstances()->toBe(2)
+            ->and($response)->maxInstances()->toBe(10);
+    });
+
+    it('deletes a deployment via facade', function (): void {
+        Saloon::fake([
+            DeleteDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/delete-deployment-success'),
+        ]);
+
+        $result = replicateDriver()->deployments()->delete('acme', 'my-deployment');
+
+        expect($result)->toBeTrue();
+    });
+
+});
+
+describe('Replicate Deployment Predictions via Facade', function (): void {
+
+    it('creates prediction via deployment', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $response = replicateDriver()
+            ->deployment('acme/my-deployment')
+            ->with(['prompt' => 'A beautiful sunset over mountains'])
+            ->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class)
+            ->and($response)->id->toBe('abc123xyz789prediction');
+    });
+
+    it('creates prediction via deployment with webhook', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $response = replicateDriver()
+            ->deployment('acme/my-deployment')
+            ->with(['prompt' => 'A beautiful sunset'])
+            ->webhook('https://example.com/webhook')
+            ->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class);
+    });
+
+    it('throws exception for invalid deployment format', function (): void {
+        expect(fn () => replicateDriver()->deployment('invalid-format'))
+            ->toThrow(InvalidArgumentException::class, "Deployment must be in 'owner/name' format");
+    });
+
+});
+
+describe('Replicate Deployments End-to-End Workflow', function (): void {
+
+    it('can perform full deployment lifecycle', function (): void {
+        // Create deployment
+        Saloon::fake([
+            CreateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-success'),
+        ]);
+
+        $created = replicateDriver()
+            ->deployments()
+            ->create('my-deployment')
+            ->model('stability-ai/sdxl')
+            ->version('da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf')
+            ->hardware('gpu-t4')
+            ->instances(1, 5)
+            ->save();
+
+        expect($created)->name->toBe('my-deployment');
+
+        // Run prediction
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $prediction = replicateDriver()
+            ->deployment('acme/my-deployment')
+            ->with(['prompt' => 'A sunset'])
+            ->run();
+
+        expect($prediction)->id->toBe('abc123xyz789prediction');
+
+        // Update deployment
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $updated = replicateDriver()
+            ->deployments()
+            ->update('acme', 'my-deployment')
+            ->hardware('gpu-a40-small')
+            ->instances(2, 10)
+            ->save();
+
+        expect($updated)->hardware()->toBe('gpu-a40-small');
+
+        // Delete deployment
+        Saloon::fake([
+            DeleteDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/delete-deployment-success'),
+        ]);
+
+        $deleted = replicateDriver()
+            ->deployments()
+            ->delete('acme', 'my-deployment');
+
+        expect($deleted)->toBeTrue();
+    });
+
+    it('handles pagination in deployment list', function (): void {
+        Saloon::fake([
+            ListDeploymentsRequest::class => MockResponse::fixture('Replicate/Deployments/list-deployments-success'),
+        ]);
+
+        $collection = replicateDriver()->deployments()->list();
+
+        expect($collection)->hasMore()->toBeTrue()
+            ->and($collection)->next()->toBe('https://api.replicate.com/v1/deployments?cursor=abc123')
+            ->and($collection)->previous()->toBeNull();
+    });
+
+});
+
+describe('Direct Driver Access', function (): void {
+
+    it('can access deployments directly from driver instance', function (): void {
+        $driver = new ReplicateDriver([
+            'api_key' => 'test-key',
+            'base_url' => 'https://api.replicate.com',
+        ]);
+
+        $manager = $driver->deployments();
+
+        expect($manager)->toBeInstanceOf(DeploymentsManager::class);
+    });
+
+});

--- a/tests/Fixtures/Saloon/Replicate/Deployments/create-deployment-prediction-success.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/create-deployment-prediction-success.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "content-type": ["application/json"]
+    },
+    "data": "{\"id\":\"abc123xyz789prediction\",\"model\":\"acme/my-deployment\",\"version\":\"da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf\",\"input\":{\"prompt\":\"A beautiful sunset over mountains\"},\"status\":\"starting\",\"created_at\":\"2024-01-15T12:00:00.000Z\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/abc123xyz789prediction\",\"cancel\":\"https://api.replicate.com/v1/predictions/abc123xyz789prediction/cancel\"}}"
+}

--- a/tests/Fixtures/Saloon/Replicate/Deployments/create-deployment-success.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/create-deployment-success.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "content-type": ["application/json"]
+    },
+    "data": "{\"owner\":\"acme\",\"name\":\"my-deployment\",\"current_release\":{\"number\":1,\"model\":\"stability-ai/sdxl\",\"version\":\"da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf\",\"hardware\":\"gpu-t4\",\"min_instances\":1,\"max_instances\":5,\"created_at\":\"2024-01-15T12:00:00.000Z\",\"created_by\":{\"type\":\"user\",\"username\":\"acme\"}}}"
+}

--- a/tests/Fixtures/Saloon/Replicate/Deployments/delete-deployment-success.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/delete-deployment-success.json
@@ -1,0 +1,5 @@
+{
+    "statusCode": 204,
+    "headers": {},
+    "data": ""
+}

--- a/tests/Fixtures/Saloon/Replicate/Deployments/get-deployment-success.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/get-deployment-success.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "content-type": ["application/json"]
+    },
+    "data": "{\"owner\":\"acme\",\"name\":\"my-deployment\",\"current_release\":{\"number\":1,\"model\":\"stability-ai/sdxl\",\"version\":\"da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf\",\"hardware\":\"gpu-t4\",\"min_instances\":1,\"max_instances\":5,\"created_at\":\"2024-01-15T12:00:00.000Z\",\"created_by\":{\"type\":\"user\",\"username\":\"acme\"}}}"
+}

--- a/tests/Fixtures/Saloon/Replicate/Deployments/list-deployments-empty.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/list-deployments-empty.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "content-type": ["application/json"]
+    },
+    "data": "{\"results\":[],\"next\":null,\"previous\":null}"
+}

--- a/tests/Fixtures/Saloon/Replicate/Deployments/list-deployments-success.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/list-deployments-success.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "content-type": ["application/json"]
+    },
+    "data": "{\"results\":[{\"owner\":\"acme\",\"name\":\"deployment-one\",\"current_release\":{\"number\":1,\"model\":\"stability-ai/sdxl\",\"version\":\"da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf\",\"hardware\":\"gpu-t4\",\"min_instances\":1,\"max_instances\":5,\"created_at\":\"2024-01-15T12:00:00.000Z\",\"created_by\":{\"type\":\"user\",\"username\":\"acme\"}}},{\"owner\":\"acme\",\"name\":\"deployment-two\",\"current_release\":{\"number\":2,\"model\":\"meta/llama-2-70b\",\"version\":\"abc123def456abc123def456abc123def456abc123def456abc123def456abcd\",\"hardware\":\"gpu-a40-small\",\"min_instances\":2,\"max_instances\":10,\"created_at\":\"2024-01-16T12:00:00.000Z\",\"created_by\":{\"type\":\"user\",\"username\":\"acme\"}}}],\"next\":\"https://api.replicate.com/v1/deployments?cursor=abc123\",\"previous\":null}"
+}

--- a/tests/Fixtures/Saloon/Replicate/Deployments/update-deployment-success.json
+++ b/tests/Fixtures/Saloon/Replicate/Deployments/update-deployment-success.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "content-type": ["application/json"]
+    },
+    "data": "{\"owner\":\"acme\",\"name\":\"my-deployment\",\"current_release\":{\"number\":2,\"model\":\"stability-ai/sdxl\",\"version\":\"da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf\",\"hardware\":\"gpu-a40-small\",\"min_instances\":2,\"max_instances\":10,\"created_at\":\"2024-01-16T12:00:00.000Z\",\"created_by\":{\"type\":\"user\",\"username\":\"acme\"}}}"
+}

--- a/tests/Unit/Drivers/Replicate/Requests/Deployments/CreateDeploymentPredictionRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Requests/Deployments/CreateDeploymentPredictionRequestTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentPredictionRequest;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+
+covers(CreateDeploymentPredictionRequest::class);
+
+describe('CreateDeploymentPredictionRequest', function (): void {
+
+    it('uses POST method', function (): void {
+        $request = new CreateDeploymentPredictionRequest('acme', 'my-deployment', ['prompt' => 'test']);
+
+        expect($request->getMethod())->toBe(Method::POST);
+    });
+
+    it('resolves endpoint with owner and name', function (): void {
+        $request = new CreateDeploymentPredictionRequest('acme', 'my-deployment', ['prompt' => 'test']);
+
+        expect($request->resolveEndpoint())->toBe('/v1/deployments/acme/my-deployment/predictions');
+    });
+
+    it('returns body with input', function (): void {
+        $input = ['prompt' => 'A beautiful sunset'];
+        $request = new CreateDeploymentPredictionRequest('acme', 'my-deployment', $input);
+
+        $body = $request->defaultBody();
+
+        expect($body)->toHaveKey('input')
+            ->and($body['input'])->toBe($input);
+    });
+
+    it('includes webhook url in body when provided', function (): void {
+        $request = new CreateDeploymentPredictionRequest(
+            owner: 'acme',
+            name: 'my-deployment',
+            input: ['prompt' => 'test'],
+            webhookUrl: 'https://example.com/webhook',
+        );
+
+        $body = $request->defaultBody();
+
+        expect($body)->toHaveKey('webhook')
+            ->and($body['webhook'])->toBe('https://example.com/webhook');
+    });
+
+    it('excludes webhook from body when not provided', function (): void {
+        $request = new CreateDeploymentPredictionRequest('acme', 'my-deployment', ['prompt' => 'test']);
+
+        $body = $request->defaultBody();
+
+        expect($body)->not->toHaveKey('webhook');
+    });
+
+    it('includes webhook events filter when provided', function (): void {
+        $request = new CreateDeploymentPredictionRequest(
+            owner: 'acme',
+            name: 'my-deployment',
+            input: ['prompt' => 'test'],
+            webhookUrl: 'https://example.com/webhook',
+            webhookEventsFilter: ['start', 'completed'],
+        );
+
+        $body = $request->defaultBody();
+
+        expect($body)->toHaveKey('webhook_events_filter')
+            ->and($body['webhook_events_filter'])->toBe(['start', 'completed']);
+    });
+
+    it('excludes webhook events filter when empty', function (): void {
+        $request = new CreateDeploymentPredictionRequest(
+            owner: 'acme',
+            name: 'my-deployment',
+            input: ['prompt' => 'test'],
+            webhookUrl: null,
+            webhookEventsFilter: [],
+        );
+
+        $body = $request->defaultBody();
+
+        expect($body)->not->toHaveKey('webhook_events_filter');
+    });
+
+    it('implements HasBody interface', function (): void {
+        $request = new CreateDeploymentPredictionRequest('acme', 'my-deployment', ['prompt' => 'test']);
+
+        expect($request)->toBeInstanceOf(HasBody::class);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Requests/Deployments/CreateDeploymentRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Requests/Deployments/CreateDeploymentRequestTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentRequest;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+
+covers(CreateDeploymentRequest::class);
+
+describe('CreateDeploymentRequest', function (): void {
+
+    it('uses POST method', function (): void {
+        $request = new CreateDeploymentRequest(
+            name: 'my-deployment',
+            model: 'stability-ai/sdxl',
+            version: 'da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf',
+            hardware: 'gpu-t4',
+            minInstances: 1,
+            maxInstances: 5,
+        );
+
+        expect($request->getMethod())->toBe(Method::POST);
+    });
+
+    it('resolves endpoint to /v1/deployments', function (): void {
+        $request = new CreateDeploymentRequest(
+            name: 'my-deployment',
+            model: 'stability-ai/sdxl',
+            version: 'da77bc59',
+            hardware: 'gpu-t4',
+            minInstances: 1,
+            maxInstances: 5,
+        );
+
+        expect($request->resolveEndpoint())->toBe('/v1/deployments');
+    });
+
+    it('returns body with all required fields', function (): void {
+        $request = new CreateDeploymentRequest(
+            name: 'my-deployment',
+            model: 'stability-ai/sdxl',
+            version: 'da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf',
+            hardware: 'gpu-t4',
+            minInstances: 1,
+            maxInstances: 5,
+        );
+
+        $body = $request->defaultBody();
+
+        expect($body)->toHaveKeys(['name', 'model', 'version', 'hardware', 'min_instances', 'max_instances'])
+            ->and($body['name'])->toBe('my-deployment')
+            ->and($body['model'])->toBe('stability-ai/sdxl')
+            ->and($body['version'])->toBe('da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf')
+            ->and($body['hardware'])->toBe('gpu-t4')
+            ->and($body['min_instances'])->toBe(1)
+            ->and($body['max_instances'])->toBe(5);
+    });
+
+    it('implements HasBody interface', function (): void {
+        $request = new CreateDeploymentRequest(
+            name: 'my-deployment',
+            model: 'stability-ai/sdxl',
+            version: 'da77bc59',
+            hardware: 'gpu-t4',
+            minInstances: 1,
+            maxInstances: 5,
+        );
+
+        expect($request)->toBeInstanceOf(HasBody::class);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Requests/Deployments/DeleteDeploymentRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Requests/Deployments/DeleteDeploymentRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\DeleteDeploymentRequest;
+use Saloon\Enums\Method;
+
+covers(DeleteDeploymentRequest::class);
+
+describe('DeleteDeploymentRequest', function (): void {
+
+    it('uses DELETE method', function (): void {
+        $request = new DeleteDeploymentRequest('acme', 'my-deployment');
+
+        expect($request->getMethod())->toBe(Method::DELETE);
+    });
+
+    it('resolves endpoint with owner and name', function (): void {
+        $request = new DeleteDeploymentRequest('acme', 'my-deployment');
+
+        expect($request->resolveEndpoint())->toBe('/v1/deployments/acme/my-deployment');
+    });
+
+    it('handles various owner and name formats', function (string $owner, string $name, string $expectedEndpoint): void {
+        $request = new DeleteDeploymentRequest($owner, $name);
+
+        expect($request->resolveEndpoint())->toBe($expectedEndpoint);
+    })->with([
+        'simple names' => ['acme', 'test', '/v1/deployments/acme/test'],
+        'hyphenated names' => ['my-org', 'my-deployment', '/v1/deployments/my-org/my-deployment'],
+    ]);
+
+});

--- a/tests/Unit/Drivers/Replicate/Requests/Deployments/GetDeploymentRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Requests/Deployments/GetDeploymentRequestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\GetDeploymentRequest;
+use Saloon\Enums\Method;
+
+covers(GetDeploymentRequest::class);
+
+describe('GetDeploymentRequest', function (): void {
+
+    it('uses GET method', function (): void {
+        $request = new GetDeploymentRequest('acme', 'my-deployment');
+
+        expect($request->getMethod())->toBe(Method::GET);
+    });
+
+    it('resolves endpoint with owner and name', function (): void {
+        $request = new GetDeploymentRequest('acme', 'my-deployment');
+
+        expect($request->resolveEndpoint())->toBe('/v1/deployments/acme/my-deployment');
+    });
+
+    it('handles various owner and name formats', function (string $owner, string $name, string $expectedEndpoint): void {
+        $request = new GetDeploymentRequest($owner, $name);
+
+        expect($request->resolveEndpoint())->toBe($expectedEndpoint);
+    })->with([
+        'simple names' => ['acme', 'test', '/v1/deployments/acme/test'],
+        'hyphenated names' => ['my-org', 'my-deployment', '/v1/deployments/my-org/my-deployment'],
+        'underscored names' => ['org_name', 'deploy_name', '/v1/deployments/org_name/deploy_name'],
+    ]);
+
+});

--- a/tests/Unit/Drivers/Replicate/Requests/Deployments/ListDeploymentsRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Requests/Deployments/ListDeploymentsRequestTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\ListDeploymentsRequest;
+use Saloon\Enums\Method;
+
+covers(ListDeploymentsRequest::class);
+
+describe('ListDeploymentsRequest', function (): void {
+
+    it('uses GET method', function (): void {
+        $request = new ListDeploymentsRequest;
+
+        expect($request->getMethod())->toBe(Method::GET);
+    });
+
+    it('resolves endpoint to /v1/deployments', function (): void {
+        $request = new ListDeploymentsRequest;
+
+        expect($request->resolveEndpoint())->toBe('/v1/deployments');
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Requests/Deployments/UpdateDeploymentRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Requests/Deployments/UpdateDeploymentRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\UpdateDeploymentRequest;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+
+covers(UpdateDeploymentRequest::class);
+
+describe('UpdateDeploymentRequest', function (): void {
+
+    it('uses PATCH method', function (): void {
+        $request = new UpdateDeploymentRequest('acme', 'my-deployment', ['hardware' => 'gpu-a40-small']);
+
+        expect($request->getMethod())->toBe(Method::PATCH);
+    });
+
+    it('resolves endpoint with owner and name', function (): void {
+        $request = new UpdateDeploymentRequest('acme', 'my-deployment', ['hardware' => 'gpu-a40-small']);
+
+        expect($request->resolveEndpoint())->toBe('/v1/deployments/acme/my-deployment');
+    });
+
+    it('returns body with update fields', function (): void {
+        $updates = [
+            'hardware' => 'gpu-a40-small',
+            'min_instances' => 2,
+            'max_instances' => 10,
+        ];
+
+        $request = new UpdateDeploymentRequest('acme', 'my-deployment', $updates);
+
+        $body = $request->defaultBody();
+
+        expect($body)->toBe($updates);
+    });
+
+    it('supports partial updates', function (): void {
+        $request = new UpdateDeploymentRequest('acme', 'my-deployment', ['hardware' => 'gpu-a40-small']);
+
+        $body = $request->defaultBody();
+
+        expect($body)->toHaveKey('hardware')
+            ->and($body)->not->toHaveKey('min_instances')
+            ->and($body)->not->toHaveKey('max_instances');
+    });
+
+    it('implements HasBody interface', function (): void {
+        $request = new UpdateDeploymentRequest('acme', 'my-deployment', ['hardware' => 'gpu-a40-small']);
+
+        expect($request)->toBeInstanceOf(HasBody::class);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Responses/DeploymentResponseTest.php
+++ b/tests/Unit/Drivers/Replicate/Responses/DeploymentResponseTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateDriver;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\GetDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+
+covers(DeploymentResponse::class);
+
+beforeEach(function (): void {
+    config([
+        'fal-ai.drivers.replicate.api_key' => 'test-replicate-key',
+        'fal-ai.drivers.replicate.base_url' => 'https://api.replicate.com',
+    ]);
+});
+
+function createDeploymentResponseFromMock(array $data): DeploymentResponse
+{
+    Saloon::fake([
+        GetDeploymentRequest::class => MockResponse::make($data, 200),
+    ]);
+
+    $driver = new ReplicateDriver([
+        'api_key' => 'test-key',
+        'base_url' => 'https://api.replicate.com',
+    ]);
+
+    return $driver->deployments()->get('test-owner', 'test-name');
+}
+
+describe('DeploymentResponse property accessors', function (): void {
+
+    it('returns owner', function (): void {
+        $response = createDeploymentResponseFromMock(['owner' => 'acme']);
+
+        expect($response)->owner->toBe('acme');
+    });
+
+    it('returns null for missing owner', function (): void {
+        $response = createDeploymentResponseFromMock([]);
+
+        expect($response)->owner->toBeNull();
+    });
+
+    it('returns name', function (): void {
+        $response = createDeploymentResponseFromMock(['name' => 'my-deployment']);
+
+        expect($response)->name->toBe('my-deployment');
+    });
+
+    it('returns null for missing name', function (): void {
+        $response = createDeploymentResponseFromMock([]);
+
+        expect($response)->name->toBeNull();
+    });
+
+    it('returns current release', function (): void {
+        $currentRelease = [
+            'number' => 1,
+            'model' => 'stability-ai/sdxl',
+            'version' => 'abc123',
+            'hardware' => 'gpu-t4',
+            'min_instances' => 1,
+            'max_instances' => 5,
+        ];
+
+        $response = createDeploymentResponseFromMock(['current_release' => $currentRelease]);
+
+        expect($response)->currentRelease->toBe($currentRelease);
+    });
+
+    it('returns null for missing current release', function (): void {
+        $response = createDeploymentResponseFromMock([]);
+
+        expect($response)->currentRelease->toBeNull();
+    });
+
+});
+
+describe('DeploymentResponse helper methods', function (): void {
+
+    it('returns hardware from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['hardware' => 'gpu-t4'],
+        ]);
+
+        expect($response)->hardware()->toBe('gpu-t4');
+    });
+
+    it('returns null hardware when no current release', function (): void {
+        $response = createDeploymentResponseFromMock([]);
+
+        expect($response)->hardware()->toBeNull();
+    });
+
+    it('returns model from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['model' => 'stability-ai/sdxl'],
+        ]);
+
+        expect($response)->model()->toBe('stability-ai/sdxl');
+    });
+
+    it('returns version from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['version' => 'da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf'],
+        ]);
+
+        expect($response)->version()->toBe('da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf');
+    });
+
+    it('returns min instances from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['min_instances' => 1],
+        ]);
+
+        expect($response)->minInstances()->toBe(1);
+    });
+
+    it('returns max instances from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['max_instances' => 5],
+        ]);
+
+        expect($response)->maxInstances()->toBe(5);
+    });
+
+    it('returns null for missing instances', function (): void {
+        $response = createDeploymentResponseFromMock([]);
+
+        expect($response)->minInstances()->toBeNull()
+            ->and($response)->maxInstances()->toBeNull();
+    });
+
+    it('returns release number from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['number' => 3],
+        ]);
+
+        expect($response)->releaseNumber()->toBe(3);
+    });
+
+    it('returns created at from current release', function (): void {
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['created_at' => '2024-01-15T12:00:00.000Z'],
+        ]);
+
+        expect($response)->createdAt()->toBe('2024-01-15T12:00:00.000Z');
+    });
+
+    it('returns created by from current release', function (): void {
+        $createdBy = ['type' => 'user', 'username' => 'acme'];
+        $response = createDeploymentResponseFromMock([
+            'current_release' => ['created_by' => $createdBy],
+        ]);
+
+        expect($response)->createdBy()->toBe($createdBy);
+    });
+
+});
+
+describe('DeploymentResponse HTTP status', function (): void {
+
+    it('returns successful for 200 response', function (): void {
+        $response = createDeploymentResponseFromMock(['owner' => 'test']);
+
+        expect($response)->successful()->toBeTrue()
+            ->and($response)->failed()->toBeFalse()
+            ->and($response)->status()->toBe(200);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Responses/DeploymentsCollectionTest.php
+++ b/tests/Unit/Drivers/Replicate/Responses/DeploymentsCollectionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateDriver;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\ListDeploymentsRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentsCollection;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+
+covers(DeploymentsCollection::class);
+
+beforeEach(function (): void {
+    config([
+        'fal-ai.drivers.replicate.api_key' => 'test-replicate-key',
+        'fal-ai.drivers.replicate.base_url' => 'https://api.replicate.com',
+    ]);
+});
+
+function createDeploymentsCollectionFromMock(array $data): DeploymentsCollection
+{
+    Saloon::fake([
+        ListDeploymentsRequest::class => MockResponse::make($data, 200),
+    ]);
+
+    $driver = new ReplicateDriver([
+        'api_key' => 'test-key',
+        'base_url' => 'https://api.replicate.com',
+    ]);
+
+    return $driver->deployments()->list();
+}
+
+describe('DeploymentsCollection pagination', function (): void {
+
+    it('returns results as array of DeploymentResponse', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [
+                ['owner' => 'acme', 'name' => 'deployment-one'],
+                ['owner' => 'acme', 'name' => 'deployment-two'],
+            ],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        $results = $collection->results();
+
+        expect($results)->toBeArray()
+            ->and($results)->toHaveCount(2)
+            ->and($results[0])->toBeInstanceOf(DeploymentResponse::class);
+
+        expect($results)->sequence(
+            fn ($item) => $item->name->toBe('deployment-one'),
+            fn ($item) => $item->name->toBe('deployment-two'),
+        );
+    });
+
+    it('returns empty array when no results', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        expect($collection)->results()->toBeArray()
+            ->and($collection)->results()->toBeEmpty();
+    });
+
+    it('returns next page URL', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => 'https://api.replicate.com/v1/deployments?cursor=abc123',
+            'previous' => null,
+        ]);
+
+        expect($collection)->next()->toBe('https://api.replicate.com/v1/deployments?cursor=abc123');
+    });
+
+    it('returns null when no next page', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        expect($collection)->next()->toBeNull();
+    });
+
+    it('returns previous page URL', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => null,
+            'previous' => 'https://api.replicate.com/v1/deployments?cursor=xyz789',
+        ]);
+
+        expect($collection)->previous()->toBe('https://api.replicate.com/v1/deployments?cursor=xyz789');
+    });
+
+    it('hasMore returns true when next page exists', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => 'https://api.replicate.com/v1/deployments?cursor=abc123',
+            'previous' => null,
+        ]);
+
+        expect($collection)->hasMore()->toBeTrue();
+    });
+
+    it('hasMore returns false when no next page', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        expect($collection)->hasMore()->toBeFalse();
+    });
+
+});
+
+describe('DeploymentsCollection helpers', function (): void {
+
+    it('returns count of deployments', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [
+                ['owner' => 'acme', 'name' => 'deployment-one'],
+                ['owner' => 'acme', 'name' => 'deployment-two'],
+                ['owner' => 'acme', 'name' => 'deployment-three'],
+            ],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        expect($collection)->count()->toBe(3);
+    });
+
+    it('returns zero count for empty collection', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        expect($collection)->count()->toBe(0);
+    });
+
+    it('returns raw data as array', function (): void {
+        $data = [
+            'results' => [['owner' => 'acme', 'name' => 'test']],
+            'next' => 'https://example.com/next',
+            'previous' => null,
+        ];
+
+        $collection = createDeploymentsCollectionFromMock($data);
+
+        expect($collection)->toArray()->toBe($data);
+    });
+
+    it('returns underlying Saloon response', function (): void {
+        $collection = createDeploymentsCollectionFromMock([
+            'results' => [],
+            'next' => null,
+            'previous' => null,
+        ]);
+
+        expect($collection)->getResponse()->toBeInstanceOf(\Saloon\Http\Response::class);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Support/DeploymentBuilderTest.php
+++ b/tests/Unit/Drivers/Replicate/Support/DeploymentBuilderTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateDriver;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\UpdateDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Support\DeploymentBuilder;
+use Cjmellor\FalAi\Exceptions\InvalidConfigurationException;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+
+covers(DeploymentBuilder::class);
+
+beforeEach(function (): void {
+    config([
+        'fal-ai.drivers.replicate.api_key' => 'test-replicate-key',
+        'fal-ai.drivers.replicate.base_url' => 'https://api.replicate.com',
+    ]);
+});
+
+function getReplicateDriver(): ReplicateDriver
+{
+    return new ReplicateDriver([
+        'api_key' => 'test-key',
+        'base_url' => 'https://api.replicate.com',
+    ]);
+}
+
+describe('DeploymentBuilder fluent interface', function (): void {
+
+    it('allows chaining all methods', function (): void {
+        $driver = getReplicateDriver();
+        $builder = $driver->deployments()->create('my-deployment');
+
+        $result = $builder
+            ->model('stability-ai/sdxl')
+            ->version('da77bc59')
+            ->hardware('gpu-t4')
+            ->instances(1, 5);
+
+        expect($result)->toBeInstanceOf(DeploymentBuilder::class);
+    });
+
+});
+
+describe('DeploymentBuilder create', function (): void {
+
+    it('creates deployment with all required fields', function (): void {
+        Saloon::fake([
+            CreateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-success'),
+        ]);
+
+        $driver = getReplicateDriver();
+        $response = $driver->deployments()
+            ->create('my-deployment')
+            ->model('stability-ai/sdxl')
+            ->version('da77bc59ee60423279fd632efb4795ab731d9e3ca9705ef3341091fb989b7eaf')
+            ->hardware('gpu-t4')
+            ->instances(1, 5)
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class)
+            ->and($response->name)->toBe('my-deployment');
+    });
+
+    it('throws exception when model is missing', function (): void {
+        $driver = getReplicateDriver();
+        $builder = $driver->deployments()
+            ->create('my-deployment')
+            ->version('da77bc59')
+            ->hardware('gpu-t4')
+            ->instances(1, 5);
+
+        expect(fn () => $builder->save())
+            ->toThrow(InvalidConfigurationException::class, 'Missing required deployment fields: model');
+    });
+
+    it('throws exception when version is missing', function (): void {
+        $driver = getReplicateDriver();
+        $builder = $driver->deployments()
+            ->create('my-deployment')
+            ->model('stability-ai/sdxl')
+            ->hardware('gpu-t4')
+            ->instances(1, 5);
+
+        expect(fn () => $builder->save())
+            ->toThrow(InvalidConfigurationException::class, 'Missing required deployment fields: version');
+    });
+
+    it('throws exception when hardware is missing', function (): void {
+        $driver = getReplicateDriver();
+        $builder = $driver->deployments()
+            ->create('my-deployment')
+            ->model('stability-ai/sdxl')
+            ->version('da77bc59')
+            ->instances(1, 5);
+
+        expect(fn () => $builder->save())
+            ->toThrow(InvalidConfigurationException::class, 'Missing required deployment fields: hardware');
+    });
+
+    it('throws exception when instances are missing', function (): void {
+        $driver = getReplicateDriver();
+        $builder = $driver->deployments()
+            ->create('my-deployment')
+            ->model('stability-ai/sdxl')
+            ->version('da77bc59')
+            ->hardware('gpu-t4');
+
+        expect(fn () => $builder->save())
+            ->toThrow(InvalidConfigurationException::class, 'instances');
+    });
+
+    it('throws exception listing all missing fields', function (): void {
+        $driver = getReplicateDriver();
+        $builder = $driver->deployments()->create('my-deployment');
+
+        expect(fn () => $builder->save())
+            ->toThrow(InvalidConfigurationException::class);
+    });
+
+});
+
+describe('DeploymentBuilder update', function (): void {
+
+    it('updates deployment with partial fields', function (): void {
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $driver = getReplicateDriver();
+        $response = $driver->deployments()
+            ->update('acme', 'my-deployment')
+            ->hardware('gpu-a40-small')
+            ->instances(2, 10)
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class)
+            ->and($response->hardware())->toBe('gpu-a40-small');
+    });
+
+    it('updates deployment with only hardware', function (): void {
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $driver = getReplicateDriver();
+        $response = $driver->deployments()
+            ->update('acme', 'my-deployment')
+            ->hardware('gpu-a40-small')
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class);
+    });
+
+    it('allows update without any fields set', function (): void {
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $driver = getReplicateDriver();
+        $response = $driver->deployments()
+            ->update('acme', 'my-deployment')
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class);
+    });
+
+    it('updates deployment with model', function (): void {
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $driver = getReplicateDriver();
+        $response = $driver->deployments()
+            ->update('acme', 'my-deployment')
+            ->model('new-owner/new-model')
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class);
+    });
+
+    it('updates deployment with version', function (): void {
+        Saloon::fake([
+            UpdateDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/update-deployment-success'),
+        ]);
+
+        $driver = getReplicateDriver();
+        $response = $driver->deployments()
+            ->update('acme', 'my-deployment')
+            ->version('new-version-hash-abc123')
+            ->save();
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Support/DeploymentPredictionRequestTest.php
+++ b/tests/Unit/Drivers/Replicate/Support/DeploymentPredictionRequestTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateDriver;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\CreateDeploymentPredictionRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\PredictionResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Support\DeploymentPredictionRequest;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+
+covers(DeploymentPredictionRequest::class);
+
+beforeEach(function (): void {
+    config([
+        'fal-ai.drivers.replicate.api_key' => 'test-replicate-key',
+        'fal-ai.drivers.replicate.base_url' => 'https://api.replicate.com',
+    ]);
+});
+
+function getReplicateDriverForPredictions(): ReplicateDriver
+{
+    return new ReplicateDriver([
+        'api_key' => 'test-key',
+        'base_url' => 'https://api.replicate.com',
+    ]);
+}
+
+describe('DeploymentPredictionRequest fluent interface', function (): void {
+
+    it('allows chaining with() method', function (): void {
+        $driver = getReplicateDriverForPredictions();
+        $request = $driver->deployment('acme/my-deployment');
+
+        $result = $request->with(['prompt' => 'A beautiful sunset']);
+
+        expect($result)->toBeInstanceOf(DeploymentPredictionRequest::class);
+    });
+
+    it('allows chaining webhook() method', function (): void {
+        $driver = getReplicateDriverForPredictions();
+        $request = $driver->deployment('acme/my-deployment');
+
+        $result = $request->webhook('https://example.com/hook');
+
+        expect($result)->toBeInstanceOf(DeploymentPredictionRequest::class);
+    });
+
+    it('allows chaining multiple methods', function (): void {
+        $driver = getReplicateDriverForPredictions();
+        $request = $driver->deployment('acme/my-deployment');
+
+        $result = $request
+            ->with(['prompt' => 'test'])
+            ->webhook('https://example.com/hook', ['start', 'completed']);
+
+        expect($result)->toBeInstanceOf(DeploymentPredictionRequest::class);
+    });
+
+});
+
+describe('DeploymentPredictionRequest run', function (): void {
+
+    it('creates prediction via deployment', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $driver = getReplicateDriverForPredictions();
+        $response = $driver->deployment('acme/my-deployment')
+            ->with(['prompt' => 'A beautiful sunset'])
+            ->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class)
+            ->and($response->id)->toBe('abc123xyz789prediction')
+            ->and($response->predictionStatus)->toBe('starting');
+    });
+
+    it('creates prediction with webhook', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $driver = getReplicateDriverForPredictions();
+        $response = $driver->deployment('acme/my-deployment')
+            ->with(['prompt' => 'A beautiful sunset'])
+            ->webhook('https://example.com/webhook')
+            ->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class);
+    });
+
+    it('creates prediction with custom webhook events', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $driver = getReplicateDriverForPredictions();
+        $response = $driver->deployment('acme/my-deployment')
+            ->with(['prompt' => 'A beautiful sunset'])
+            ->webhook('https://example.com/webhook', ['start', 'output', 'completed'])
+            ->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class);
+    });
+
+    it('creates prediction without input', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $driver = getReplicateDriverForPredictions();
+        $response = $driver->deployment('acme/my-deployment')->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class);
+    });
+
+});
+
+describe('ReplicateDriver deployment method', function (): void {
+
+    it('parses owner/name format', function (): void {
+        $driver = getReplicateDriverForPredictions();
+        $request = $driver->deployment('acme/my-deployment');
+
+        expect($request)->toBeInstanceOf(DeploymentPredictionRequest::class);
+    });
+
+    it('throws exception for invalid format', function (): void {
+        $driver = getReplicateDriverForPredictions();
+
+        expect(fn () => $driver->deployment('invalid-format'))
+            ->toThrow(InvalidArgumentException::class, "Deployment must be in 'owner/name' format");
+    });
+
+    it('handles names with multiple slashes', function (): void {
+        Saloon::fake([
+            CreateDeploymentPredictionRequest::class => MockResponse::fixture('Replicate/Deployments/create-deployment-prediction-success'),
+        ]);
+
+        $driver = getReplicateDriverForPredictions();
+        $response = $driver->deployment('acme/my/complex/name')
+            ->with(['prompt' => 'test'])
+            ->run();
+
+        expect($response)->toBeInstanceOf(PredictionResponse::class);
+    });
+
+});

--- a/tests/Unit/Drivers/Replicate/Support/DeploymentsManagerTest.php
+++ b/tests/Unit/Drivers/Replicate/Support/DeploymentsManagerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\FalAi\Drivers\Replicate\ReplicateDriver;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\DeleteDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\GetDeploymentRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Requests\Deployments\ListDeploymentsRequest;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentResponse;
+use Cjmellor\FalAi\Drivers\Replicate\Responses\DeploymentsCollection;
+use Cjmellor\FalAi\Drivers\Replicate\Support\DeploymentBuilder;
+use Cjmellor\FalAi\Drivers\Replicate\Support\DeploymentsManager;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+
+covers(DeploymentsManager::class);
+
+beforeEach(function (): void {
+    config([
+        'fal-ai.drivers.replicate.api_key' => 'test-replicate-key',
+        'fal-ai.drivers.replicate.base_url' => 'https://api.replicate.com',
+    ]);
+});
+
+function getDeploymentsManager(): DeploymentsManager
+{
+    $driver = new ReplicateDriver([
+        'api_key' => 'test-key',
+        'base_url' => 'https://api.replicate.com',
+    ]);
+
+    return $driver->deployments();
+}
+
+describe('DeploymentsManager list', function (): void {
+
+    it('returns DeploymentsCollection', function (): void {
+        Saloon::fake([
+            ListDeploymentsRequest::class => MockResponse::fixture('Replicate/Deployments/list-deployments-success'),
+        ]);
+
+        $manager = getDeploymentsManager();
+        $collection = $manager->list();
+
+        expect($collection)->toBeInstanceOf(DeploymentsCollection::class)
+            ->and($collection->count())->toBe(2);
+    });
+
+    it('handles empty list', function (): void {
+        Saloon::fake([
+            ListDeploymentsRequest::class => MockResponse::fixture('Replicate/Deployments/list-deployments-empty'),
+        ]);
+
+        $manager = getDeploymentsManager();
+        $collection = $manager->list();
+
+        expect($collection)->toBeInstanceOf(DeploymentsCollection::class)
+            ->and($collection->count())->toBe(0)
+            ->and($collection->hasMore())->toBeFalse();
+    });
+
+});
+
+describe('DeploymentsManager get', function (): void {
+
+    it('returns DeploymentResponse', function (): void {
+        Saloon::fake([
+            GetDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/get-deployment-success'),
+        ]);
+
+        $manager = getDeploymentsManager();
+        $response = $manager->get('acme', 'my-deployment');
+
+        expect($response)->toBeInstanceOf(DeploymentResponse::class)
+            ->and($response->owner)->toBe('acme')
+            ->and($response->name)->toBe('my-deployment');
+    });
+
+});
+
+describe('DeploymentsManager create', function (): void {
+
+    it('returns DeploymentBuilder for create', function (): void {
+        $manager = getDeploymentsManager();
+        $builder = $manager->create('my-new-deployment');
+
+        expect($builder)->toBeInstanceOf(DeploymentBuilder::class);
+    });
+
+});
+
+describe('DeploymentsManager update', function (): void {
+
+    it('returns DeploymentBuilder for update', function (): void {
+        $manager = getDeploymentsManager();
+        $builder = $manager->update('acme', 'my-deployment');
+
+        expect($builder)->toBeInstanceOf(DeploymentBuilder::class);
+    });
+
+});
+
+describe('DeploymentsManager delete', function (): void {
+
+    it('returns true on successful delete', function (): void {
+        Saloon::fake([
+            DeleteDeploymentRequest::class => MockResponse::fixture('Replicate/Deployments/delete-deployment-success'),
+        ]);
+
+        $manager = getDeploymentsManager();
+        $result = $manager->delete('acme', 'my-deployment');
+
+        expect($result)->toBeTrue();
+    });
+
+});


### PR DESCRIPTION
## Summary

Adds full support for the Replicate Deployments API, enabling auto-scaling model inference with custom deployments.

### Features

- **CRUD Operations**: Create, list, get, update, and delete deployments via `DeploymentsManager`
- **Fluent Builder**: `DeploymentBuilder` for chainable deployment configuration (model, version, hardware, instances)
- **Prediction Support**: Run predictions via deployments with `DeploymentPredictionRequest`
- **Response Wrappers**: `DeploymentResponse` and `DeploymentsCollection` with pagination support
- **Hardware Enum**: Type-safe hardware SKU selection (cpu, gpu-t4, gpu-a100-large, etc.)

### Usage

```php
// Create a deployment
$deployment = Ai::driver('replicate')
    ->deployments()
    ->create('my-deployment')
    ->model('stability-ai/sdxl')
    ->version('da77bc59...')
    ->hardware('gpu-t4')
    ->instances(1, 5)
    ->save();

// Run prediction via deployment
$prediction = Ai::driver('replicate')
    ->deployment('owner/my-deployment')
    ->with(['prompt' => 'A sunset'])
    ->run();
```

### Changes

- Add `Hardware` enum with available Replicate SKUs
- Add deployment request classes (Create, Get, List, Update, Delete, CreatePrediction)
- Add `DeploymentResponse` and `DeploymentsCollection` response wrappers
- Add `DeploymentsManager`, `DeploymentBuilder`, `DeploymentPredictionRequest` support classes
- Add `deployments()` and `deployment()` methods to `ReplicateDriver`
- Add comprehensive test coverage (unit + feature tests)
- Update README with Deployments documentation
- Update CLAUDE.md with Deployments API docs and coding conventions

## Test Plan

- [x] All existing tests pass
- [x] New unit tests for request classes
- [x] New unit tests for response classes
- [x] New unit tests for support classes (Manager, Builder, PredictionRequest)
- [x] Feature tests for full deployment workflows
- [x] Architecture tests updated for new classes